### PR TITLE
docs: clusterpackage does not need a namespace field

### DIFF
--- a/content/en/docs/guides/installing-packages.md
+++ b/content/en/docs/guides/installing-packages.md
@@ -32,7 +32,6 @@ apiVersion: package-operator.run/v1alpha1
 kind: ClusterPackage
 metadata:
   name: example
-  namespace: default
 spec:
   image: packageImage
 


### PR DESCRIPTION
`ClusterPackage` is Cluster-scoped and thus does not need/use the `metadata.namespace` field. The example works regardless so this is mostly to avoid confusing the reader